### PR TITLE
Remove importlib-resources from requirements (#6431)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ gevent==22.10.1
 greenlet==1.1.3
 gunicorn==20.0.4
 httplib2==0.19.0
-importlib-resources==5.13.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 jsonschema==3.1.1


### PR DESCRIPTION
This is not required for Python >= 3.8 since the goal of this project is to back port functionality.  Also the version specified is not compatible with later versions of Python.

https://pypi.org/project/importlib-resources/

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
